### PR TITLE
pc- create databse table for help requests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
@@ -26,10 +26,10 @@ public class UCSBDate {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long id;
 
-private String requesterEmail
-private String teamId
-private String tableOrBreakoutRoom
-private LocalDateTime requestTime
-private String explanation
-private boolean solved
+private String requesterEmail;
+private String teamId;
+private String tableOrBreakoutRoom;
+private LocalDateTime requestTime;
+private String explanation;
+private boolean solved;
 }

--- a/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
@@ -12,16 +12,15 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 /**
- * This is a JPA entity that represents a UCSBDate, i.e. an entry
- * that comes from the UCSB API for academic calendar dates.
+ * This is a JPA entity that represents a HelpRequest
  */
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-@Entity(name = "ucsbdates")
-public class UCSBDate {
+@Entity(name = "helprequests")
+public class HelpRequest {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long id;

--- a/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
@@ -1,0 +1,35 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * This is a JPA entity that represents a UCSBDate, i.e. an entry
+ * that comes from the UCSB API for academic calendar dates.
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "ucsbdates")
+public class UCSBDate {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+private String requesterEmail
+private String teamId
+private String tableOrBreakoutRoom
+private LocalDateTime requestTime
+private String explanation
+private boolean solved
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/HelpRequestRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/HelpRequestRepository.java
@@ -1,0 +1,22 @@
+package edu.ucsb.cs156.example.repositories;
+
+
+import edu.ucsb.cs156.example.entities.HelpRequest;
+
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+
+/**
+* The HelpRequestRepository is a repository for HelpRequest entities.
+*/
+
+
+@Repository
+public interface HelpRequestRepository extends CrudRepository<HelpRequest, Long> {
+
+
+
+
+}

--- a/src/main/resources/db/migration/changes/HelpRequest.json
+++ b/src/main/resources/db/migration/changes/HelpRequest.json
@@ -1,0 +1,94 @@
+{
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "HelpRequest-1",
+        "author": "saahasburicha",
+        "preConditions": [
+          {
+            "onFail": "MARK_RAN"
+          },
+          {
+            "not": [
+              {
+                "tableExists": {
+                  "tableName": "HELPREQUESTS"
+                }
+              }
+            ]
+          }
+        ],
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "primaryKey": true,
+                      "primaryKeyName": "HELPREQUESTS_PK"
+                    },
+                    "name": "ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "REQUESTER_EMAIL",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "TEAM_ID",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "TABLE_OR_BREAKOUT_ROOM",
+                    "type": "BIGINT"
+                  }
+
+
+                },
+                {
+                  "column": {
+                    "name": "REQUEST_TIME",
+                    "type": "TIMESTAMP WITH TIME ZONE"
+                  }
+
+
+                },
+                {
+                  "column": {
+                    "name": "EXPLANATION",
+                    "type": "VARCHAR(255)"
+                  }
+
+
+                },
+                {
+                  "column": {
+                    "name": "SOLVED",
+                    "type": "BOOLEAN"
+                  }
+
+
+                }
+
+
+               
+              ],
+              "tableName": "HELPREQUESTS"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+
+
+


### PR DESCRIPTION
Closes #32 

In this PR, we add a database table that represents a HelpRequest with the following fields:

```
private long id;
private String requesterEmail;
private String teamId;
private String tableOrBreakoutRoom;
private LocalDateTime requestTime;
private String explanation;
private boolean solved;

```

this can be tested by looking at H2 console on localhost

<img width="166" alt="Screenshot 2025-04-25 at 5 33 44 PM" src="https://github.com/user-attachments/assets/38c57c67-3a15-46ca-aa71-a82a7dc5a9d9" />

This can also be tested by running on dokku and connecting to the postgres database and running \dt.

<img width="561" alt="Screenshot 2025-04-25 at 5 35 01 PM" src="https://github.com/user-attachments/assets/282d4f43-ec7b-4d2d-bd17-8cb0a81b9bb0" />

