### PR TITLE
Pc put for helprequest table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
@@ -105,5 +105,23 @@ public class HelpRequestController extends ApiController{
         return savedHelpRequest;
     }
 
+     /**
+     * Get a single HelpRequest by id
+     * 
+     * @param id the id of the HelpRequest
+     * @return a HelpRequest
+     */
+    @Operation(summary= "Get a single HelpRequest")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public HelpRequest getById(
+            @Parameter(name="id") @RequestParam Long id) {
+        HelpRequest helpRequest = helpRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(HelpRequest.class, id));
+
+        return helpRequest;
+    }
+
+
 
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
@@ -1,0 +1,109 @@
+package edu.ucsb.cs156.example.controllers;
+
+
+import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
+import edu.ucsb.cs156.example.entities.HelpRequest;
+import java.time.ZonedDateTime;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+
+import java.time.LocalDateTime;
+
+/**
+ * This is a REST controller for HelpRequests
+ */
+
+@Tag(name = "HelpRequests")
+@RequestMapping("/api/helprequests")
+@RestController
+@Slf4j
+public class HelpRequestController extends ApiController{
+
+    @Autowired
+    HelpRequestRepository helpRequestRepository;
+
+
+      /**
+     * List all HelpRequests
+     * 
+     * @return an iterable of HelpRequests
+     */
+    @Operation(summary= "List all help requests")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<HelpRequest> allHelpRequests() {
+        Iterable<HelpRequest> helprequests = helpRequestRepository.findAll();
+        return helprequests;
+    }
+
+
+      /**
+     * Create a new HelpRequest
+     * 
+     * @param requesterEmail  the email of the person submitting helprequest
+     * @param teamId        the ID of the team
+     * @param tableOrBreakoutRoom the name of the table that needs help
+     * @param requestTime the time of the request
+     * @param explanation explanation of what need help with
+     * @param solved  tells us whether the helprequest is solved or not 
+     * 
+     * @return the saved helprequest 
+     */
+    @Operation(summary= "Create a new helprequest")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public HelpRequest postHelpRequest(
+            @Parameter(name="requesterEmail") @RequestParam String requesterEmail,
+            @Parameter(name="teamId") @RequestParam String teamId,
+            @Parameter(name="tableOrBreakoutRoom") @RequestParam String tableOrBreakoutRoom,
+            @Parameter(name="explanation") @RequestParam String explanation,
+            @Parameter(name="solved") @RequestParam Boolean solved,
+            @Parameter(name="requestTime", description="date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)") @RequestParam("requestTime") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) ZonedDateTime requestTime)
+
+            throws JsonProcessingException {
+
+        // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        // See: https://www.baeldung.com/spring-date-parameters
+
+        log.info("requestTime={}", requestTime);
+
+
+        HelpRequest helpRequest = new HelpRequest();
+        helpRequest.setRequesterEmail(requesterEmail);
+        helpRequest.setTeamId(teamId);
+        helpRequest.setTableOrBreakoutRoom(tableOrBreakoutRoom);
+        helpRequest.setRequestTime(requestTime);
+        helpRequest.setExplanation(explanation);
+        helpRequest.setSolved(solved);
+
+
+
+        HelpRequest savedHelpRequest = helpRequestRepository.save(helpRequest);
+
+        return savedHelpRequest;
+    }
+
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
@@ -123,5 +123,40 @@ public class HelpRequestController extends ApiController{
     }
 
 
+     /**
+     * Update a single helprequest
+     * 
+     * @param id       id of the helprequest to update
+     * @param incoming the new helprequest
+     * @return the updated helprequest object
+     */
+    @Operation(summary= "Update a single helprequest")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public HelpRequest updateHelpRequest(
+            @Parameter(name="id") @RequestParam Long id,
+            @RequestBody @Valid HelpRequest incoming) {
+
+        HelpRequest helpRequest = helpRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(HelpRequest.class, id));
+
+
+
+        helpRequest.setRequesterEmail(incoming.getRequesterEmail());
+        helpRequest.setTeamId(incoming.getTeamId());
+        helpRequest.setTableOrBreakoutRoom(incoming.getTableOrBreakoutRoom());
+        helpRequest.setRequestTime(incoming.getRequestTime());
+        helpRequest.setExplanation(incoming.getExplanation());
+        helpRequest.setSolved(incoming.getSolved());
+
+        helpRequestRepository.save(helpRequest);
+
+        return helpRequest;
+    }
+
+
+
+
+
 
 }

--- a/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
@@ -8,7 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
+import java.time.ZonedDateTime;
 import java.time.LocalDateTime;
 
 /**
@@ -28,7 +28,7 @@ public class HelpRequest {
 private String requesterEmail;
 private String teamId;
 private String tableOrBreakoutRoom;
-private LocalDateTime requestTime;
+private ZonedDateTime requestTime;
 private String explanation;
 private boolean solved;
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestsControllerTests.java
@@ -156,5 +156,65 @@ public class HelpRequestsControllerTests extends ControllerTestCase{
                 assertEquals(expectedJson, responseString);
         }
 
+         @Test
+        public void logged_out_users_cannot_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/helprequests?id=7"))
+                                .andExpect(status().is(403)); // logged out users can't get by id
+        }
+
+         @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+
+                when(helpRequestRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/helprequests?id=7"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(helpRequestRepository, times(1)).findById(eq(7L));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("HelpRequest with id 7 not found", json.get("message"));
+        }
+
+         public void test_that_logged_in_user_can_get_by_id_when_the_id_does_exist() throws Exception {
+
+                ZonedDateTime z1 = ZonedDateTime.parse("2022-01-03T00:00:00Z");
+
+
+                HelpRequest helprequest1 = HelpRequest.builder()
+                        .requesterEmail("cgaucho@ucsb.edu")
+                        .teamId("s22-5pm-3")
+                        .tableOrBreakoutRoom("7")
+                        .requestTime(z1)
+                        .explanation("dokku-issue")
+                        .solved(false)
+                        .build();
+
+                // arrange
+
+                when(helpRequestRepository.findById(eq(7L))).thenReturn(Optional.of(helprequest1));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/helprequests?id=7"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(helpRequestRepository, times(1)).findById(eq(7L));
+                String expectedJson = mapper.writeValueAsString(helprequest1);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+                
+        }
+
+
+
+
 
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestsControllerTests.java
@@ -1,0 +1,160 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import edu.ucsb.cs156.example.controllers.HelpRequestController;
+import edu.ucsb.cs156.example.entities.HelpRequest;
+import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
+
+
+
+@WebMvcTest(controllers = HelpRequestController.class)
+@Import(TestConfig.class)
+
+
+
+public class HelpRequestsControllerTests extends ControllerTestCase{
+
+        @MockBean
+        HelpRequestRepository helpRequestRepository;
+
+        @MockBean
+        UserRepository userRepository;
+
+        @Autowired
+        ObjectMapper mapper;
+
+
+        @Test
+        public void logged_out_users_cannot_get_all() throws Exception {
+                mockMvc.perform(get("/api/helprequests/all"))
+                                .andExpect(status().is(403)); // logged out users can't get all
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/helprequests/all"))
+                                .andExpect(status().is(200)); // logged
+        }
+
+          @Test
+        public void logged_out_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/helprequests/post"))
+                                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/helprequests/post"))
+                                .andExpect(status().is(403)); // only admins can post
+        }
+
+
+         @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_user_can_get_all_helprequests() throws Exception {
+
+                // arrange
+
+                ZonedDateTime z1 = ZonedDateTime.parse("2022-01-03T00:00:00Z");
+
+
+                HelpRequest helprequest1 = HelpRequest.builder()
+                        .requesterEmail("cgaucho@ucsb.edu")
+                        .teamId("s22-5pm-3")
+                        .tableOrBreakoutRoom("7")
+                        .requestTime(z1)
+                        .explanation("Issue with dokku")
+                        .solved(false)
+                        .build();
+
+
+                
+
+                ArrayList<HelpRequest> expectedHelpRequests = new ArrayList<>();
+                expectedHelpRequests.add(helprequest1);
+
+                when(helpRequestRepository.findAll()).thenReturn(expectedHelpRequests);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/helprequests/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(helpRequestRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedHelpRequests);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+
+         @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_post_a_new_helprequest() throws Exception {
+                // arrange 
+
+                ZonedDateTime z1 = ZonedDateTime.parse("2022-01-03T00:00:00Z");
+
+
+                HelpRequest helprequest1 = HelpRequest.builder()
+                        .requesterEmail("cgaucho@ucsb.edu")
+                        .teamId("s22-5pm-3")
+                        .tableOrBreakoutRoom("7")
+                        .requestTime(z1)
+                        .explanation("dokku-issue")
+                        .solved(false)
+                        .build();
+
+                when(helpRequestRepository.save(eq(helprequest1))).thenReturn(helprequest1);
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/helprequests/post?requesterEmail=cgaucho@ucsb.edu&teamId=s22-5pm-3&tableOrBreakoutRoom=7&requestTime=2022-01-03T00:00:00Z&explanation=dokku-issue&solved=false")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(helpRequestRepository, times(1)).save(helprequest1);
+                String expectedJson = mapper.writeValueAsString(helprequest1);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestsControllerTests.java
@@ -214,6 +214,96 @@ public class HelpRequestsControllerTests extends ControllerTestCase{
         }
 
 
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_edit_an_existing_helprequest() throws Exception {
+                // arrange
+
+                // LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+                // LocalDateTime ldt2 = LocalDateTime.parse("2023-01-03T00:00:00");
+
+                ZonedDateTime z1 = ZonedDateTime.parse("2022-01-03T00:00:00Z");
+
+                ZonedDateTime z2 = ZonedDateTime.parse("2022-01-04T00:00:00Z");
+
+                 HelpRequest helprequestOrig = HelpRequest.builder()
+                        .requesterEmail("cgaucho@ucsb.edu")
+                        .teamId("s22-5pm-3")
+                        .tableOrBreakoutRoom("7")
+                        .requestTime(z1)
+                        .explanation("dokku-issue")
+                        .solved(false)
+                        .build();
+
+                 HelpRequest helprequestEdit = HelpRequest.builder()
+                        .requesterEmail("sburicha@ucsb.edu")
+                        .teamId("s22-6pm-4")
+                        .tableOrBreakoutRoom("5")
+                        .requestTime(z2)
+                        .explanation("jacoco-issue")
+                        .solved(false)
+                        .build();
+
+                
+
+                String requestBody = mapper.writeValueAsString(helprequestEdit);
+
+                when(helpRequestRepository.findById(eq(67L))).thenReturn(Optional.of(helprequestOrig));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/helprequests?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(helpRequestRepository, times(1)).findById(67L);
+                verify(helpRequestRepository, times(1)).save(helprequestEdit); 
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(requestBody, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_cannot_edit_helprequest_that_does_not_exist() throws Exception {
+                // arrange
+
+                ZonedDateTime z1 = ZonedDateTime.parse("2022-02-03T00:00:00Z");
+
+                HelpRequest helprequestEdit = HelpRequest.builder()
+                        .requesterEmail("cgauch@ucsb.edu")
+                        .teamId("s22-7pm-3")
+                        .tableOrBreakoutRoom("10")
+                        .requestTime(z1)
+                        .explanation("github-issue")
+                        .solved(false)
+                        .build();
+
+                String requestBody = mapper.writeValueAsString(helprequestEdit);
+
+                when(helpRequestRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                put("/api/helprequests?id=67")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .characterEncoding("utf-8")
+                                                .content(requestBody)
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(helpRequestRepository, times(1)).findById(67L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("HelpRequest with id 67 not found", json.get("message"));
+
+        }
+
+
+
 
 
 


### PR DESCRIPTION
In this PR, I add the PUT operations for the helprequest controller so that users can edit existing help requests. 
<img width="717" alt="Screenshot 2025-04-28 at 12 15 48 AM" src="https://github.com/user-attachments/assets/e66282a2-bdb6-4225-aff6-bed2084de5cc" />

It can be seen in this picture on the swagger

