### PR TITLE
pc- added delete endpoint to the helprequest controller 

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
@@ -155,6 +155,26 @@ public class HelpRequestController extends ApiController{
     }
 
 
+      /**
+     * Delete a HelpRequest
+     * 
+     * @param id the id of the helprequest to delete
+     * @return a message indicating the date was deleted
+     */
+    @Operation(summary= "Delete a HelpRequest")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteHelpRequest(
+            @Parameter(name="id") @RequestParam Long id) {
+        HelpRequest helpRequest = helpRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(HelpRequest.class, id));
+
+        helpRequestRepository.delete(helpRequest);
+        
+        return genericMessage("HelpRequest with id %s deleted".formatted(id));
+    }
+
+
 
 
 

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestsControllerTests.java
@@ -85,7 +85,7 @@ public class HelpRequestsControllerTests extends ControllerTestCase{
         }
 
 
-         @WithMockUser(roles = { "USER" })
+        @WithMockUser(roles = { "USER" })
         @Test
         public void logged_in_user_can_get_all_helprequests() throws Exception {
 
@@ -124,7 +124,7 @@ public class HelpRequestsControllerTests extends ControllerTestCase{
         }
 
 
-         @WithMockUser(roles = { "ADMIN", "USER" })
+        @WithMockUser(roles = { "ADMIN", "USER" })
         @Test
         public void an_admin_user_can_post_a_new_helprequest() throws Exception {
                 // arrange 
@@ -182,6 +182,8 @@ public class HelpRequestsControllerTests extends ControllerTestCase{
                 assertEquals("HelpRequest with id 7 not found", json.get("message"));
         }
 
+        @WithMockUser(roles = { "USER" })
+        @Test 
          public void test_that_logged_in_user_can_get_by_id_when_the_id_does_exist() throws Exception {
 
                 ZonedDateTime z1 = ZonedDateTime.parse("2022-01-03T00:00:00Z");
@@ -301,6 +303,61 @@ public class HelpRequestsControllerTests extends ControllerTestCase{
                 assertEquals("HelpRequest with id 67 not found", json.get("message"));
 
         }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_delete_a_helprequest() throws Exception {
+                // arrange
+
+                ZonedDateTime z1 = ZonedDateTime.parse("2023-06-03T00:00:00Z");
+
+                HelpRequest helprequestEdit = HelpRequest.builder()
+                        .requesterEmail("sgauch@ucsb.edu")
+                        .teamId("s23-7pm-3")
+                        .tableOrBreakoutRoom("1")
+                        .requestTime(z1)
+                        .explanation("github-issue")
+                        .solved(false)
+                        .build();
+              
+
+                when(helpRequestRepository.findById(eq(15L))).thenReturn(Optional.of(helprequestEdit));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/helprequests?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(helpRequestRepository, times(1)).findById(15L);
+                verify(helpRequestRepository, times(1)).delete(eq(helprequestEdit));
+
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("HelpRequest with id 15 deleted", json.get("message"));
+        }
+
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_tries_to_delete_non_existant_helprequest_and_gets_right_error_message()
+                        throws Exception {
+                // arrange
+
+                when(helpRequestRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/helprequests?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(helpRequestRepository, times(1)).findById(15L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("HelpRequest with id 15 not found", json.get("message"));
+        }
+
 
 
 


### PR DESCRIPTION
Closes #36.

In this PR, i was able to add the delete endpoint for the HelpRequest Controller as you can see in this picutre below here
<img width="1109" alt="Screenshot 2025-04-28 at 7 04 50 PM" src="https://github.com/user-attachments/assets/492fe957-fb0e-492d-8192-ab94438e006b" />


I also added tests to test the delete endpoint and those tests were added to the HelpRequestsControllerTests.java class. When running the tests they all passed with no errors.